### PR TITLE
coming soon copy, disabled dropdown

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -331,7 +331,7 @@ class App extends React.Component {
               <Main>
                 <MainLeft>
                   <h1>Claim KSM</h1>
-                  <h2>Coming soon: 17 July, 4:00PM UTC</h2>
+                  <h2>Coming soon: 17 July, 4PM UTC</h2>
                   <br/>
                   <p>This DApp will walk you through the process of claiming KSM. In order to claim KSM you need to have an allocation of DOTs.</p>
                   <h2>Create a Kusama address</h2>


### PR DESCRIPTION
Hey @lsaether , this is a hacky pr to: 

- temporarily disable dropdown to claim
- copy to say dapp is launching tomorrow instead of today

Since comms are going out in ~1 hour and linking to claim.kusama.network... i want to make sure no one is actually claiming with the dapp until we are ready.